### PR TITLE
Json Schema - Add support for mapping styles 

### DIFF
--- a/compiler/src/main/java/org/hisrc/jsonix/compilation/jsonschema/JsonSchemaPropertyInfoProducerVisitor.java
+++ b/compiler/src/main/java/org/hisrc/jsonix/compilation/jsonschema/JsonSchemaPropertyInfoProducerVisitor.java
@@ -155,10 +155,15 @@ public class JsonSchemaPropertyInfoProducerVisitor<T, C extends T>
 			itemTypeSchemas.add(new JsonSchemaBuilder().addRef(JsonixJsonSchemaConstants.DOM_TYPE_INFO_SCHEMA_REF));
 		}
 		if (info.isTypedObjectAllowed()) {
-			final JsonSchemaBuilder anyElementSchema = new JsonSchemaBuilder().addType(JsonSchemaConstants.OBJECT_TYPE)
-					.addProperty(JsonixConstants.NAME_PROPERTY_NAME,
-							new JsonSchemaBuilder().addRef(XmlSchemaJsonSchemaConstants.QNAME_TYPE_INFO_SCHEMA_REF))
-					.addProperty(JsonixConstants.VALUE_PROPERTY_NAME, new JsonSchemaBuilder());
+			final JsonSchemaBuilder anyElementSchema;
+            if (mappingCompiler.getMapping().getMappingStyle().equals("simplified")) {
+				anyElementSchema = new JsonSchemaBuilder();
+			} else {
+				anyElementSchema = new JsonSchemaBuilder().addType(JsonSchemaConstants.OBJECT_TYPE)
+						.addProperty(JsonixConstants.NAME_PROPERTY_NAME,
+								new JsonSchemaBuilder().addRef(XmlSchemaJsonSchemaConstants.QNAME_TYPE_INFO_SCHEMA_REF))
+						.addProperty(JsonixConstants.VALUE_PROPERTY_NAME, new JsonSchemaBuilder());
+			}
 			itemTypeSchemas.add(anyElementSchema);
 		}
 		final JsonSchemaBuilder typeSchema = createPossiblyCollectionTypeSchema(info,
@@ -259,13 +264,18 @@ public class JsonSchemaPropertyInfoProducerVisitor<T, C extends T>
 	}
 
 	private <M extends MElementTypeInfo<T, C, O>, O> JsonSchemaBuilder createElementRefSchema(M elementTypeInfo) {
-		final JsonSchemaBuilder schema = new JsonSchemaBuilder();
-		addElementNameSchema(elementTypeInfo.getElementName(), schema);
-		schema.addType(JsonSchemaConstants.OBJECT_TYPE);
-		schema.addProperty(JsonixConstants.NAME_PROPERTY_NAME,
-				new JsonSchemaBuilder().addRef(XmlSchemaJsonSchemaConstants.QNAME_TYPE_INFO_SCHEMA_REF));
-		schema.addProperty(JsonixConstants.VALUE_PROPERTY_NAME,
-				createTypeSchema(elementTypeInfo, elementTypeInfo.getTypeInfo()));
+		final JsonSchemaBuilder schema;
+		if (mappingCompiler.getMapping().getMappingStyle().equals("simplified")) {
+			schema = createTypeSchema(elementTypeInfo, elementTypeInfo.getTypeInfo());
+		} else {
+			schema = new JsonSchemaBuilder();
+			addElementNameSchema(elementTypeInfo.getElementName(), schema);
+			schema.addType(JsonSchemaConstants.OBJECT_TYPE);
+			schema.addProperty(JsonixConstants.NAME_PROPERTY_NAME,
+					new JsonSchemaBuilder().addRef(XmlSchemaJsonSchemaConstants.QNAME_TYPE_INFO_SCHEMA_REF));
+			schema.addProperty(JsonixConstants.VALUE_PROPERTY_NAME,
+					createTypeSchema(elementTypeInfo, elementTypeInfo.getTypeInfo()));
+		}
 		return schema;
 	}
 

--- a/compiler/src/main/java/org/hisrc/jsonix/configuration/MappingConfiguration.java
+++ b/compiler/src/main/java/org/hisrc/jsonix/configuration/MappingConfiguration.java
@@ -29,12 +29,14 @@ public class MappingConfiguration {
 	public static final String MAPPING_NAME_PROPERTY = "${mapping.name}";
 	public static final String MAPPING_TARGET_NAMESPACE_URI_PROPERTY = "${mapping.targetNamespace}";
 	public static final String LOCAL_ELEMENT_NAME = "mapping";
+	public static final String DEFAULT_MAPPING_STYLE = "default";
 
 	private ModuleConfiguration moduleConfiguration;
 	private String id;
 	private String name;
 	private String _package;
 	private String schemaId = MappingConfiguration.MAPPING_TARGET_NAMESPACE_URI_PROPERTY + "#";
+	private String mappingStyle;
 	private String targetNamespaceURI;
 	private String defaultElementNamespaceURI;
 	private String defaultAttributeNamespaceURI;
@@ -80,6 +82,15 @@ public class MappingConfiguration {
 
 	public void setSchemaId(String schemaId) {
 		this.schemaId = schemaId;
+	}
+
+	@XmlAttribute(name = "mappingStyle")
+	public String getMappingStyle() {
+		return mappingStyle;
+	}
+
+	public void setMappingStyle(String mappingStyle) {
+		this.mappingStyle = mappingStyle;
 	}
 
 	@XmlAttribute(name = "targetNamespace")
@@ -198,8 +209,18 @@ public class MappingConfiguration {
 				.replace(MappingConfiguration.MAPPING_NAME_PROPERTY, getName())
 				.replace(MappingConfiguration.MAPPING_TARGET_NAMESPACE_URI_PROPERTY, targetNamespaceURI);
 
+		final String mappingStyle;
+		if (this.mappingStyle != null) {
+			mappingStyle = this.mappingStyle;
+		} else {
+			logger.debug(MessageFormat
+					.format("Mapping [{0}] will use Standard Mapping Style in the package [{2}].",
+							mappingName, packageName));
+			mappingStyle = MappingConfiguration.DEFAULT_MAPPING_STYLE;
+		}
+
 		final Mapping<T, C> mapping = new Mapping<T, C>(context, analyzer,
-				packageInfo, mappingName, mappingSchemaId, targetNamespaceURI,
+				packageInfo, mappingName, mappingSchemaId, mappingStyle, targetNamespaceURI,
 				defaultElementNamespaceURI, defaultAttributeNamespaceURI);
 
 		if (getExcludesConfiguration() != null) {

--- a/compiler/src/main/java/org/hisrc/jsonix/definition/Mapping.java
+++ b/compiler/src/main/java/org/hisrc/jsonix/definition/Mapping.java
@@ -47,6 +47,7 @@ public class Mapping<T, C extends T> {
 	private final String packageName;
 	private final String mappingName;
 	private final String schemaId;
+	private final String mappingStyle;
 	private final String targetNamespaceURI;
 	private final String defaultElementNamespaceURI;
 	private final String defaultAttributeNamespaceURI;
@@ -54,7 +55,7 @@ public class Mapping<T, C extends T> {
 
 	public Mapping(JsonixContext context,
 			ModelInfoGraphAnalyzer<T, C> analyzer, MPackageInfo packageInfo,
-			String mappingName, String schemaId, String targetNamespaceURI,
+			String mappingName, String schemaId, String mappingStyle, String targetNamespaceURI,
 			String defaultElementNamespaceURI,
 			String defaultAttributeNamespaceURI) {
 		this.logger = Validate.notNull(context).getLoggerFactory()
@@ -63,6 +64,7 @@ public class Mapping<T, C extends T> {
 		Validate.notNull(packageInfo);
 		Validate.notNull(mappingName);
 		Validate.notNull(schemaId);
+		Validate.notNull(mappingStyle);
 		Validate.notNull(defaultElementNamespaceURI);
 		Validate.notNull(defaultAttributeNamespaceURI);
 		this.analyzer = analyzer;
@@ -70,6 +72,7 @@ public class Mapping<T, C extends T> {
 		this.packageName = packageInfo.getPackageName();
 		this.mappingName = mappingName;
 		this.schemaId = schemaId;
+		this.mappingStyle = mappingStyle;
 		this.targetNamespaceURI = targetNamespaceURI;
 		this.defaultElementNamespaceURI = defaultElementNamespaceURI;
 		this.defaultAttributeNamespaceURI = defaultAttributeNamespaceURI;
@@ -450,6 +453,10 @@ public class Mapping<T, C extends T> {
 
 	public String getSchemaId() {
 		return this.schemaId;
+	}
+
+	public String getMappingStyle() {
+		return this.mappingStyle;
 	}
 
 	public String getTargetNamespaceURI() {


### PR DESCRIPTION
Similar to jsonix [mapping styles](https://github.com/highsource/jsonix/wiki/Mapping-Styles)  feature this change enables  the use of a [Simplified Mapping Style](https://github.com/highsource/jsonix/wiki/Simplified-Mapping-Style) as an alternative to the [Standard Mapping Style](https://github.com/highsource/jsonix/wiki/Standard-Mapping-Style) for the generated Json Schemas.