### PR TITLE
Add javax.activation dependency to support Java>8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,11 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>javax.activation</groupId>
+			<artifactId>activation</artifactId>
+			<version>1.1.1</version>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
javax.activation was removed from Java>8

I could not generate a schema without this dependency because of this:

```
Exception in thread "main" java.lang.NoClassDefFoundError: javax/activation/DataSource
        at com.sun.xml.bind.v2.model.impl.RuntimeBuiltinLeafInfoImpl.<clinit>(RuntimeBuiltinLeafInfoImpl.java:470)
        at com.sun.xml.bind.v2.model.impl.RuntimeTypeInfoSetImpl.<init>(RuntimeTypeInfoSetImpl.java:63)
        at com.sun.xml.bind.v2.model.impl.RuntimeModelBuilder.createTypeInfoSet(RuntimeModelBuilder.java:128)
        at com.sun.xml.bind.v2.model.impl.RuntimeModelBuilder.createTypeInfoSet(RuntimeModelBuilder.java:84)
        at com.sun.xml.bind.v2.model.impl.ModelBuilder.<init>(ModelBuilder.java:162)
        at com.sun.xml.bind.v2.model.impl.RuntimeModelBuilder.<init>(RuntimeModelBuilder.java:92)
        at com.sun.xml.bind.v2.runtime.JAXBContextImpl.getTypeInfoSet(JAXBContextImpl.java:444)
        at com.sun.xml.bind.v2.runtime.JAXBContextImpl.<init>(JAXBContextImpl.java:292)
        at com.sun.xml.bind.v2.runtime.JAXBContextImpl.<init>(JAXBContextImpl.java:139)
        at com.sun.xml.bind.v2.runtime.JAXBContextImpl$JAXBContextBuilder.build(JAXBContextImpl.java:1138)
        at com.sun.xml.bind.v2.ContextFactory.createContext(ContextFactory.java:162)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at javax.xml.bind.ContextFinder.newInstance(ContextFinder.java:262)
        at javax.xml.bind.ContextFinder.newInstance(ContextFinder.java:249)
        at javax.xml.bind.ContextFinder.find(ContextFinder.java:456)
        at javax.xml.bind.JAXBContext.newInstance(JAXBContext.java:656)
        at javax.xml.bind.JAXBContext.newInstance(JAXBContext.java:599)
        at com.sun.tools.xjc.reader.xmlschema.bindinfo.BindInfo.getCustomizationContext(BindInfo.java:336)
        at com.sun.tools.xjc.reader.xmlschema.bindinfo.BindInfo.getCustomizationUnmarshaller(BindInfo.java:362)
        at com.sun.tools.xjc.reader.xmlschema.bindinfo.AnnotationParserFactoryImpl$1.<init>(AnnotationParserFactoryImpl.java:85)
        at com.sun.tools.xjc.reader.xmlschema.bindinfo.AnnotationParserFactoryImpl.create(AnnotationParserFactoryImpl.java:84)
        at com.sun.xml.xsom.impl.parser.NGCCRuntimeEx.createAnnotationParser(NGCCRuntimeEx.java:365)
        at com.sun.xml.xsom.impl.parser.state.annotation.action0(annotation.java:88)
        at com.sun.xml.xsom.impl.parser.state.annotation.enterElement(annotation.java:113)
        at com.sun.xml.xsom.impl.parser.state.NGCCRuntime.sendEnterElement(NGCCRuntime.java:417)
        at com.sun.xml.xsom.impl.parser.state.NGCCHandler.spawnChildFromEnterElement(NGCCHandler.java:113)
        at com.sun.xml.xsom.impl.parser.state.elementDeclBody.enterElement(elementDeclBody.java:187)
        at com.sun.xml.xsom.impl.parser.state.NGCCRuntime.sendEnterElement(NGCCRuntime.java:417)
        at com.sun.xml.xsom.impl.parser.state.elementDeclBody.enterElement(elementDeclBody.java:285)
        at com.sun.xml.xsom.impl.parser.state.NGCCRuntime.sendEnterElement(NGCCRuntime.java:417)
        at com.sun.xml.xsom.impl.parser.state.elementDeclBody.enterElement(elementDeclBody.java:132)
        at com.sun.xml.xsom.impl.parser.state.NGCCRuntime.sendEnterElement(NGCCRuntime.java:417)
        at com.sun.xml.xsom.impl.parser.state.elementDeclBody.enterElement(elementDeclBody.java:199)
        at com.sun.xml.xsom.impl.parser.state.NGCCRuntime.sendEnterElement(NGCCRuntime.java:417)
        at com.sun.xml.xsom.impl.parser.state.elementDeclBody.enterElement(elementDeclBody.java:179)
        at com.sun.xml.xsom.impl.parser.state.NGCCRuntime.sendEnterElement(NGCCRuntime.java:417)
        at com.sun.xml.xsom.impl.parser.state.elementDeclBody.enterElement(elementDeclBody.java:144)
        at com.sun.xml.xsom.impl.parser.state.NGCCRuntime.sendEnterElement(NGCCRuntime.java:417)
        at com.sun.xml.xsom.impl.parser.state.elementDeclBody.enterElement(elementDeclBody.java:167)
        at com.sun.xml.xsom.impl.parser.state.NGCCRuntime.sendEnterElement(NGCCRuntime.java:417)
        at com.sun.xml.xsom.impl.parser.state.elementDeclBody.enterElement(elementDeclBody.java:297)
        at com.sun.xml.xsom.impl.parser.state.NGCCRuntime.sendEnterElement(NGCCRuntime.java:417)
        at com.sun.xml.xsom.impl.parser.state.elementDeclBody.enterElement(elementDeclBody.java:226)
        at com.sun.xml.xsom.impl.parser.state.NGCCRuntime.sendEnterElement(NGCCRuntime.java:417)
        at com.sun.xml.xsom.impl.parser.state.elementDeclBody.enterElement(elementDeclBody.java:214)
        at com.sun.xml.xsom.impl.parser.state.NGCCRuntime.sendEnterElement(NGCCRuntime.java:417)
        at com.sun.xml.xsom.impl.parser.state.NGCCHandler.revertToParentFromEnterElement(NGCCHandler.java:150)
        at com.sun.xml.xsom.impl.parser.state.foreignAttributes.enterElement(foreignAttributes.java:90)
        at com.sun.xml.xsom.impl.parser.state.NGCCRuntime.sendEnterElement(NGCCRuntime.java:417)
        at com.sun.xml.xsom.impl.parser.state.NGCCHandler.spawnChildFromEnterElement(NGCCHandler.java:113)
        at com.sun.xml.xsom.impl.parser.state.elementDeclBody.enterElement(elementDeclBody.java:234)
        at com.sun.xml.xsom.impl.parser.state.NGCCRuntime.sendEnterElement(NGCCRuntime.java:417)
        at com.sun.xml.xsom.impl.parser.state.NGCCHandler.spawnChildFromEnterElement(NGCCHandler.java:113)
        at com.sun.xml.xsom.impl.parser.state.Schema.enterElement(Schema.java:390)
        at com.sun.xml.xsom.impl.parser.state.NGCCRuntime.startElement(NGCCRuntime.java:258)
        at java.xml/org.xml.sax.helpers.XMLFilterImpl.startElement(XMLFilterImpl.java:551)
        at com.sun.tools.xjc.util.SubtreeCutter.startElement(SubtreeCutter.java:108)
        at com.sun.tools.xjc.reader.ExtensionBindingChecker.startElement(ExtensionBindingChecker.java:150)
        at java.xml/org.xml.sax.helpers.XMLFilterImpl.startElement(XMLFilterImpl.java:551)
        at com.sun.tools.xjc.reader.xmlschema.parser.IncorrectNamespaceURIChecker.startElement(IncorrectNamespaceURIChecker.java:128)
        at java.xml/org.xml.sax.helpers.XMLFilterImpl.startElement(XMLFilterImpl.java:551)
        at com.sun.tools.xjc.reader.xmlschema.parser.CustomizationContextChecker.startElement(CustomizationContextChecker.java:193)
        at java.xml/org.xml.sax.helpers.XMLFilterImpl.startElement(XMLFilterImpl.java:551)
        at com.sun.tools.xjc.ModelLoader$SpeculationChecker.startElement(ModelLoader.java:473)
        at java.xml/org.xml.sax.helpers.XMLFilterImpl.startElement(XMLFilterImpl.java:551)
        at com.sun.tools.xjc.reader.internalizer.VersionChecker.startElement(VersionChecker.java:103)
        at java.xml/org.xml.sax.helpers.XMLFilterImpl.startElement(XMLFilterImpl.java:551)
        at java.xml/com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser.startElement(AbstractSAXParser.java:510)
        at java.xml/com.sun.org.apache.xerces.internal.impl.XMLNSDocumentScannerImpl.scanStartElement(XMLNSDocumentScannerImpl.java:374)
        at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl$FragmentContentDriver.next(XMLDocumentFragmentScannerImpl.java:2710)
        at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl.next(XMLDocumentScannerImpl.java:605)
        at java.xml/com.sun.org.apache.xerces.internal.impl.XMLNSDocumentScannerImpl.next(XMLNSDocumentScannerImpl.java:112)
        at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanDocument(XMLDocumentFragmentScannerImpl.java:534)
        at java.xml/com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:888)
        at java.xml/com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:824)
        at java.xml/com.sun.org.apache.xerces.internal.parsers.XMLParser.parse(XMLParser.java:141)
        at java.xml/com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser.parse(AbstractSAXParser.java:1216)
        at java.xml/com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl$JAXPSAXParser.parse(SAXParserImpl.java:635)
        at java.xml/org.xml.sax.helpers.XMLFilterImpl.parse(XMLFilterImpl.java:357)
        at com.sun.xml.xsom.parser.JAXPParser.parse(JAXPParser.java:100)
        at com.sun.tools.xjc.ModelLoader$2.parse(ModelLoader.java:497)
        at com.sun.tools.xjc.ModelLoader$XMLSchemaParser.parse(ModelLoader.java:269)
        at com.sun.xml.xsom.impl.parser.NGCCRuntimeEx.parseEntity(NGCCRuntimeEx.java:347)
        at com.sun.xml.xsom.impl.parser.ParserContext.parse(ParserContext.java:128)
        at com.sun.xml.xsom.parser.XSOMParser.parse(XSOMParser.java:171)
        at com.sun.tools.xjc.ModelLoader.createXSOMSpeculative(ModelLoader.java:514)
        at com.sun.tools.xjc.ModelLoader.loadXMLSchema(ModelLoader.java:369)
        at com.sun.tools.xjc.ModelLoader.load(ModelLoader.java:174)
        at com.sun.tools.xjc.ModelLoader.load(ModelLoader.java:119)
        at org.hisrc.jsonix.JsonixMain.execute(JsonixMain.java:99)
        at org.hisrc.jsonix.JsonixMain.main(JsonixMain.java:77)
Caused by: java.lang.ClassNotFoundException: javax.activation.DataSource
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
        ... 94 more
```
